### PR TITLE
Do not return null values from iterators

### DIFF
--- a/src/hashiter.rs
+++ b/src/hashiter.rs
@@ -56,7 +56,7 @@ where
             let current = self.current;
             if let Some(cell) = self.map.get_cell_at_index(current) {
                 self.current = current + 1;
-                if cell.is_empty() {
+                if cell.is_empty() || cell.value.is_null() {
                     continue;
                 }
 
@@ -146,7 +146,7 @@ where
             let current = self.current;
             if let Some(cell) = self.map.get_cell_at_index(current) {
                 self.current = current + 1;
-                if cell.is_empty() {
+                if cell.is_empty() || cell.value.is_null() {
                     continue;
                 }
 
@@ -224,7 +224,7 @@ where
             let current = self.current;
             if let Some(cell) = self.map.get_cell_at_index_mut(current) {
                 self.current = current + 1;
-                if cell.is_empty() {
+                if cell.is_empty() || cell.value.is_null() {
                     continue;
                 }
 

--- a/src/leapref.rs
+++ b/src/leapref.rs
@@ -97,6 +97,9 @@ where
     {
         loop {
             let value = self.cell.value.load(Ordering::Relaxed);
+            if value.is_null() {
+                return None;
+            }
             let key = self.cell.key.load(Ordering::Relaxed);
             if value.is_redirect() || self.hash != self.cell.hash.load(Ordering::Relaxed) {
                 // Map has/is being migrated, help and then try again ...
@@ -196,6 +199,9 @@ where
     {
         loop {
             let value = self.cell.value.load(Ordering::Relaxed);
+            if value.is_null() {
+                return None;
+            }
             let key = self.cell.key.load(Ordering::Relaxed);
             if value.is_redirect() || self.hash != self.cell.hash.load(Ordering::Relaxed) {
                 // Map has/is being migrated, help and then try again ...

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -256,6 +256,14 @@ fn leapmap_iter() {
     }
 
     assert_eq!(count, KEYS);
+
+    for k in kv_map.keys() {
+        map.remove(k);
+    }
+
+    for mut item in map.iter() {
+        assert!(item.key_value().is_none());
+    }
 }
 
 #[test]
@@ -292,5 +300,13 @@ fn leapmap_iter_mut() {
             panic!("LeapMap value is incorrect");
         }
         count += 1;
+    }
+
+    for k in kv_map.keys() {
+        map.remove(k);
+    }
+
+    for mut item in map.iter() {
+        assert!(item.key_value().is_none());
     }
 }

--- a/tests/hashmap.rs
+++ b/tests/hashmap.rs
@@ -201,6 +201,13 @@ fn hashmap_iter() {
     }
 
     assert_eq!(count, KEYS);
+
+    for k in kv_map.keys() {
+        map.remove(k);
+    }
+
+    assert!(map.is_empty());
+    assert!(map.iter().next().is_none());
 }
 
 #[test]
@@ -230,4 +237,11 @@ fn hashmap_iter_mut() {
     }
 
     assert_eq!(count, KEYS);
+
+    for k in kv_map.keys() {
+        map.remove(k);
+    }
+
+    assert!(map.is_empty());
+    assert!(map.iter_mut().next().is_none());
 }


### PR DESCRIPTION
Fixes https://github.com/robclu/leapfrog/issues/10

Instead of returning `Ref`/`RefMut` containing a null value from `LeapMap`'s iterators, we can skip returning it at the cost of one additional `load`, but that is up to the maintainer's choice.