### PR TITLE
Use #![no_std] by default

### DIFF
--- a/src/hashentry.rs
+++ b/src/hashentry.rs
@@ -10,7 +10,7 @@ use allocator_api2::alloc::{Allocator, Global};
 #[cfg(not(feature = "stable_alloc"))]
 use core::alloc::Allocator;
 #[cfg(not(feature = "stable_alloc"))]
-use std::alloc::Global;
+use alloc::alloc::Global;
 
 /// A view into a single entry in a map, which may either be vacant or occupied.
 ///

--- a/src/hashiter.rs
+++ b/src/hashiter.rs
@@ -5,7 +5,7 @@ use core::hash::{BuildHasher, Hash};
 #[cfg(feature = "stable_alloc")]
 use allocator_api2::alloc::Allocator;
 #[cfg(not(feature = "stable_alloc"))]
-use std::alloc::Allocator;
+use alloc::alloc::Allocator;
 
 /// Iterator over a [`HashMap`] which yields key-value pairs.
 ///

--- a/src/hashmap.rs
+++ b/src/hashmap.rs
@@ -14,18 +14,18 @@ use core::{
     hash::{BuildHasher, BuildHasherDefault, Hash, Hasher},
 };
 
+#[cfg(not(feature = "stable_alloc"))]
+use alloc::alloc::Global;
 #[cfg(feature = "stable_alloc")]
 use allocator_api2::alloc::{Allocator, Global};
 #[cfg(not(feature = "stable_alloc"))]
 use core::alloc::Allocator;
-#[cfg(not(feature = "stable_alloc"))]
-use std::alloc::Global;
 
 // Re export the entry api.
 pub use crate::hashentry::{Entry, OccupiedEntry, VacantEntry};
 
 /// The default hasher for a [`HashMap`].
-pub(crate) type DefaultHash = std::collections::hash_map::DefaultHasher;
+pub(crate) type DefaultHash = crate::FnvHasher;
 
 /// A [`HashMap`] implementation which uses a modified form of RobinHood/Hopscotch
 /// probing. This implementation is efficient, roughly 2x the performance of
@@ -699,21 +699,21 @@ where
         let bucket_count = cells >> 2;
         let bucket_ptr =
             allocate::<Bucket<K, V>, A>(allocator, bucket_count, AllocationKind::Uninitialized);
-        let buckets = unsafe { std::slice::from_raw_parts_mut(bucket_ptr, bucket_count) };
+        let buckets = unsafe { core::slice::from_raw_parts_mut(bucket_ptr, bucket_count) };
 
         // Since AtomicU8 and AtomicU64 are the same as u8 and u64 in memory,
         // we can write them as zero, rather than calling the atomic versions
         for i in 0..bucket_count {
             unsafe {
                 let bucket_deltas = &mut buckets[i].deltas as *mut u8;
-                std::ptr::write_bytes(bucket_deltas, 0, 8);
+                core::ptr::write_bytes(bucket_deltas, 0, 8);
             };
 
             for cell in 0..4 {
                 // FIXME: How to initialize keys?
                 unsafe {
                     let cell_hash: *mut HashedKey = &mut buckets[i].cells[cell].hash;
-                    std::ptr::write_bytes(cell_hash, 0, 1);
+                    core::ptr::write_bytes(cell_hash, 0, 1);
                 };
 
                 // FIXME: We should check if the stored type is directly writable ..
@@ -967,12 +967,12 @@ struct Table<K, V> {
 impl<K, V> Table<K, V> {
     /// Gets a mutable slice of the table buckets.
     fn bucket_slice_mut(&mut self) -> &mut [Bucket<K, V>] {
-        unsafe { std::slice::from_raw_parts_mut(self.buckets, self.size()) }
+        unsafe { core::slice::from_raw_parts_mut(self.buckets, self.size()) }
     }
 
     /// Gets a slice of the table buckets.
     fn bucket_slice(&self) -> &[Bucket<K, V>] {
-        unsafe { std::slice::from_raw_parts(self.buckets, self.size()) }
+        unsafe { core::slice::from_raw_parts(self.buckets, self.size()) }
     }
 
     /// Returns the number of cells in the table.
@@ -994,7 +994,7 @@ struct Bucket<K, V> {
     /// Cells for the bucket.
     cells: [Cell<K, V>; 4],
     /// Placeholder for the key
-    _key: std::marker::PhantomData<K>,
+    _key: core::marker::PhantomData<K>,
 }
 
 /// Defines the result of an insert into the [HashMap].

--- a/src/hashmap_serde.rs
+++ b/src/hashmap_serde.rs
@@ -17,7 +17,7 @@ use allocator_api2::alloc::{Allocator, Global};
 #[cfg(not(feature = "stable_alloc"))]
 use core::alloc::Allocator;
 #[cfg(not(feature = "stable_alloc"))]
-use std::alloc::Global;
+use alloc::alloc::Global;
 
 pub struct HashMapVisitor<K, V, H> {
     marker: PhantomData<fn() -> HashMap<K, V, H, Global>>,
@@ -38,7 +38,7 @@ where
 
 impl<'de, K, V, H> Visitor<'de> for HashMapVisitor<K, V, H>
 where
-    K: Deserialize<'de> + Eq + Hash + Clone + std::fmt::Debug,
+    K: Deserialize<'de> + Eq + Hash + Clone + core::fmt::Debug,
     V: Deserialize<'de> + Value,
     H: BuildHasher + Clone + Default,
 {
@@ -65,7 +65,7 @@ where
 
 impl<'de, K, V, H> Deserialize<'de> for HashMap<K, V, H, Global>
 where
-    K: Deserialize<'de> + Eq + Hash + Clone + std::fmt::Debug,
+    K: Deserialize<'de> + Eq + Hash + Clone + core::fmt::Debug,
     V: Deserialize<'de> + Value,
     H: BuildHasher + Clone + Default,
 {

--- a/src/leapmap.rs
+++ b/src/leapmap.rs
@@ -16,15 +16,17 @@ use core::{
     sync::atomic::{AtomicBool, AtomicPtr, AtomicU32, AtomicU64, AtomicU8, AtomicUsize, Ordering},
 };
 
+use alloc::{vec, vec::Vec};
+
+#[cfg(not(feature = "stable_alloc"))]
+use alloc::alloc::Global;
 #[cfg(feature = "stable_alloc")]
 use allocator_api2::alloc::{Allocator, Global};
 #[cfg(not(feature = "stable_alloc"))]
 use core::alloc::Allocator;
-#[cfg(not(feature = "stable_alloc"))]
-use std::alloc::Global;
 
 /// The default hasher for a [`LeapMap`].
-pub(crate) type DefaultHash = std::collections::hash_map::DefaultHasher;
+pub(crate) type DefaultHash = crate::FnvHasher;
 
 /// A concurrent hash map implementation which uses a modified form of RobinHood/
 /// Hopscotch probing. This implementation is lock-free, and therefore it will
@@ -51,7 +53,7 @@ pub(crate) type DefaultHash = std::collections::hash_map::DefaultHasher;
 /// # Limitations
 ///
 /// This biggest limitations of this map are that the interface is slightly
-/// different than using [`std::sync::RwLock<HashMap>`]. The type returned
+/// different than using [`core::sync::RwLock<HashMap>`]. The type returned
 /// when calling `get`, `get_mut`, `iter`, etc, are not references, but rather a
 /// [`Ref`] or [`RefMut`] type which acts like a reference but still allows concurrent
 /// operations on both that reference type and the map. This interface is still
@@ -975,7 +977,7 @@ where
             migrator.overflowed.store(false, Ordering::Relaxed);
             //migrator
             //    .dst_table
-            //    .store(std::ptr::null_mut(), Ordering::Relaxed);
+            //    .store(core::ptr::null_mut(), Ordering::Relaxed);
 
             // We don't move the source tables here, rather, we wait until the
             // next mogration and add them to the cleanup queue then.
@@ -1263,21 +1265,21 @@ where
         let bucket_count = cells >> 2;
         let bucket_ptr =
             allocate::<Bucket<K, V>, A>(allocator, bucket_count, AllocationKind::Uninitialized);
-        let buckets = unsafe { std::slice::from_raw_parts_mut(bucket_ptr, bucket_count) };
+        let buckets = unsafe { core::slice::from_raw_parts_mut(bucket_ptr, bucket_count) };
 
         // Since AtomicU8 and AtomicU64 are the same as u8 and u64 in memory,
         // we can write them as zero, rather than calling the atomic versions
         for bucket in buckets.iter_mut().take(bucket_count) {
             unsafe {
                 let bucket_deltas = &mut bucket.deltas as *mut AtomicU8;
-                std::ptr::write_bytes(bucket_deltas, 0, 8);
+                core::ptr::write_bytes(bucket_deltas, 0, 8);
             };
 
             for cell in 0..4 {
                 unsafe {
                     // We only need to write the hash as null, an can ignore th key.
                     let cell_hash: *mut AtomicHashedKey = &mut bucket.cells[cell].hash;
-                    std::ptr::write_bytes(cell_hash, 0, 1);
+                    core::ptr::write_bytes(cell_hash, 0, 1);
                 };
 
                 // FIXME: Check if the stored type is directly writable ..
@@ -1476,12 +1478,12 @@ struct Table<K, V> {
 impl<K, V> Table<K, V> {
     /// Gets a mutable slice of the table buckets.
     pub(super) fn bucket_slice_mut(&mut self) -> &mut [Bucket<K, V>] {
-        unsafe { std::slice::from_raw_parts_mut(self.buckets, self.size()) }
+        unsafe { core::slice::from_raw_parts_mut(self.buckets, self.size()) }
     }
 
     /// Gets a slice of the table buckets.
     pub(super) fn bucket_slice(&self) -> &[Bucket<K, V>] {
-        unsafe { std::slice::from_raw_parts(self.buckets, self.size()) }
+        unsafe { core::slice::from_raw_parts(self.buckets, self.size()) }
     }
 
     /// Returns the number of cells in the table.
@@ -1589,11 +1591,11 @@ impl<K, V> Migrator<K, V> {
         self.stale_sources = Vec::with_capacity(Self::STALE_SOURCES);
         for _ in 0..Self::STALE_SOURCES {
             self.stale_sources
-                .push(AtomicPtr::<Table<K, V>>::new(std::ptr::null_mut()));
+                .push(AtomicPtr::<Table<K, V>>::new(core::ptr::null_mut()));
         }
 
         self.dst_table
-            .store(std::ptr::null_mut(), Ordering::Relaxed);
+            .store(core::ptr::null_mut(), Ordering::Relaxed);
         self.sources = vec![];
         self.status.store(Self::RESET_FLAG, Ordering::Relaxed);
         self.remaining_units.store(0, Ordering::Relaxed);
@@ -1681,7 +1683,7 @@ impl<K, V> Migrator<K, V> {
             let bucket_count = table.size() >> 2;
             deallocate::<Bucket<K, V>, A>(allocator, bucket_ptr, bucket_count);
             deallocate::<Table<K, V>, A>(allocator, table_ptr, 1);
-            self.stale_sources[index].store(std::ptr::null_mut(), Ordering::Relaxed);
+            self.stale_sources[index].store(core::ptr::null_mut(), Ordering::Relaxed);
         }
 
         // Lost the race, just return.

--- a/src/leapmap_serde.rs
+++ b/src/leapmap_serde.rs
@@ -17,7 +17,7 @@ use allocator_api2::alloc::{Allocator, Global};
 #[cfg(not(feature = "stable_alloc"))]
 use core::alloc::Allocator;
 #[cfg(not(feature = "stable_alloc"))]
-use std::alloc::Global;
+use alloc::alloc::Global;
 
 pub struct LeapMapVisitor<K, V, H> {
     marker: PhantomData<fn() -> LeapMap<K, V, H, Global>>,
@@ -38,7 +38,7 @@ where
 
 impl<'de, K, V, H> Visitor<'de> for LeapMapVisitor<K, V, H>
 where
-    K: Deserialize<'de> + Eq + Hash + Copy + std::fmt::Debug,
+    K: Deserialize<'de> + Eq + Hash + Copy + core::fmt::Debug,
     V: Deserialize<'de> + Value,
     H: BuildHasher + Clone + Default,
 {
@@ -65,7 +65,7 @@ where
 
 impl<'de, K, V, H> Deserialize<'de> for LeapMap<K, V, H, Global>
 where
-    K: Deserialize<'de> + Eq + Hash + Copy + std::fmt::Debug,
+    K: Deserialize<'de> + Eq + Hash + Copy + core::fmt::Debug,
     V: Deserialize<'de> + Value,
     H: BuildHasher + Clone + Default,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,10 @@
 //! If/when the `allocator_api` feature is no longer experimental, this feature flag will
 //! be removed.
 
+#![no_std]
 #![cfg_attr(not(feature = "stable_alloc"), feature(allocator_api))]
+
+extern crate alloc;
 
 mod hashentry;
 mod hashiter;

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use core::{
 #[cfg(feature = "stable_alloc")]
 use allocator_api2::alloc::Allocator;
 #[cfg(not(feature = "stable_alloc"))]
-use core::alloc::Allocator;
+use alloc::alloc::Allocator;
 
 /// Loads the buffer `buf` as a u64.
 #[inline(always)]
@@ -17,7 +17,7 @@ pub fn load_u64_le(buf: &[u8], len: usize) -> u64 {
     let mut data = 0u64;
     let ptr: *mut _ = &mut data;
     unsafe {
-        std::ptr::copy_nonoverlapping(buf.as_ptr(), ptr as *mut u8, len);
+        core::ptr::copy_nonoverlapping(buf.as_ptr(), ptr as *mut u8, len);
     }
     data.to_le()
 }
@@ -35,7 +35,7 @@ where
         + From<usize>,
 {
     let v = value - T::from(1);
-    let res = match std::mem::size_of::<T>() {
+    let res = match core::mem::size_of::<T>() {
         1 => {
             let v = v | (v >> T::from(1));
             let v = v | (v >> T::from(2));
@@ -81,8 +81,8 @@ pub(crate) fn allocate<T, A: Allocator>(
     count: usize,
     kind: AllocationKind,
 ) -> *mut T {
-    let size = std::mem::size_of::<T>();
-    let align = std::mem::align_of::<T>();
+    let size = core::mem::size_of::<T>();
+    let align = core::mem::align_of::<T>();
 
     // We unwrap here because we want to panic if we fail to get a valid layout
     let layout = Layout::from_size_align(size * count, align).unwrap();
@@ -96,15 +96,15 @@ pub(crate) fn allocate<T, A: Allocator>(
 
 /// Deallocates `count` number of elements of type T, using the `allocator`.
 pub(crate) fn deallocate<T, A: Allocator>(allocator: &A, ptr: *mut T, count: usize) {
-    let size = std::mem::size_of::<T>();
-    let align = std::mem::align_of::<T>();
+    let size = core::mem::size_of::<T>();
+    let align = core::mem::align_of::<T>();
 
     // We unwrap here because we want to panic if we fail to get a valid layout
     let layout = Layout::from_size_align(size * count, align).unwrap();
 
     // Again, unwrap the allocation result. It should never fail to allocate.
     let raw_ptr = ptr as *mut u8;
-    let nonnull_ptr = std::ptr::NonNull::new(raw_ptr).unwrap();
+    let nonnull_ptr = core::ptr::NonNull::new(raw_ptr).unwrap();
     unsafe {
         allocator.deallocate(nonnull_ptr, layout);
     }


### PR DESCRIPTION
`#![no_std]` makes this crate usable for kernel development.