### PR TITLE
Fix LeapMap migration bugs and add concurrent benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,16 @@ serde_crate = { package = "serde", version = "1.0.136", features = ["derive"], o
 [dev-dependencies]
 core_affinity = "0.8.1"
 criterion = "0.5.1"
+dashmap = "6"
 rand = "0.8.4"
 serde_json = "1.0.50"
 
 [[bench]]
 name = "hashmap"
+harness = false
+
+[[bench]]
+name = "leapmap"
 harness = false
 
 [package.metadata.docs.rs]

--- a/benches/leapmap.rs
+++ b/benches/leapmap.rs
@@ -1,0 +1,237 @@
+//! Benchmarks for [`LeapMap`] concurrent operations.
+//!
+//! Each group runs the same workload across multiple map implementations so
+//! Criterion can produce side-by-side comparisons:
+//!
+//! | Baseline            | Rationale                                                  |
+//! |---------------------|------------------------------------------------------------|
+//! | `DashMap`           | Popular sharded concurrent map                             |
+//! | `Mutex<HashMap>`    | Coarse-grained lock; all ops serialize (floor for writes)  |
+//! | `RwLock<HashMap>`   | Concurrent reads, exclusive writes (floor for reads)       |
+
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use criterion::{criterion_group, criterion_main};
+use dashmap::DashMap;
+use leapfrog::LeapMap;
+use rand::{thread_rng, Rng};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
+
+const NUM_KEYS: usize = 1 << 14; // 16 384, pre-population size for get bench
+const OPS_PER_THREAD: usize = 10_000;
+
+fn num_threads() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+}
+
+// ---------------------------------------------------------------------------
+// concurrent_insert
+// ---------------------------------------------------------------------------
+
+/// N threads each insert `OPS_PER_THREAD` unique keys into a fresh map.
+///
+/// Thread creation is included in the measurement (conservative / slightly
+/// pessimistic), but is consistent across all variants so comparisons are fair.
+fn bench_concurrent_insert(c: &mut Criterion) {
+    let n = num_threads();
+    let mut group = c.benchmark_group("concurrent_insert");
+    group.throughput(Throughput::Elements((n * OPS_PER_THREAD) as u64));
+    group.sample_size(10);
+
+    group.bench_function("leapmap", |b| {
+        b.iter(|| {
+            let map: Arc<LeapMap<usize, usize>> = Arc::new(LeapMap::new());
+            let handles: Vec<_> = (0..n)
+                .map(|t| {
+                    let m = Arc::clone(&map);
+                    std::thread::spawn(move || {
+                        let base = t * OPS_PER_THREAD;
+                        for i in 0..OPS_PER_THREAD {
+                            m.insert(base + i, i);
+                        }
+                    })
+                })
+                .collect();
+            for h in handles {
+                h.join().unwrap();
+            }
+        });
+    });
+
+    group.bench_function("dashmap", |b| {
+        b.iter(|| {
+            let map: Arc<DashMap<usize, usize>> = Arc::new(DashMap::new());
+            let handles: Vec<_> = (0..n)
+                .map(|t| {
+                    let m = Arc::clone(&map);
+                    std::thread::spawn(move || {
+                        let base = t * OPS_PER_THREAD;
+                        for i in 0..OPS_PER_THREAD {
+                            m.insert(base + i, i);
+                        }
+                    })
+                })
+                .collect();
+            for h in handles {
+                h.join().unwrap();
+            }
+        });
+    });
+
+    group.bench_function("mutex_hashmap", |b| {
+        b.iter(|| {
+            let map: Arc<Mutex<HashMap<usize, usize>>> =
+                Arc::new(Mutex::new(HashMap::new()));
+            let handles: Vec<_> = (0..n)
+                .map(|t| {
+                    let m = Arc::clone(&map);
+                    std::thread::spawn(move || {
+                        let base = t * OPS_PER_THREAD;
+                        for i in 0..OPS_PER_THREAD {
+                            m.lock().unwrap().insert(base + i, i);
+                        }
+                    })
+                })
+                .collect();
+            for h in handles {
+                h.join().unwrap();
+            }
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// concurrent_get
+// ---------------------------------------------------------------------------
+
+/// N threads each perform `OPS_PER_THREAD` random reads on a pre-populated map.
+///
+/// Maps are filled once outside the timed loop so setup cost is excluded.
+/// `RwLock<HashMap>` allows concurrent reads; `Mutex<HashMap>` degenerates to
+/// serial reads and is omitted here since it would be dominated by `RwLock`.
+fn bench_concurrent_get(c: &mut Criterion) {
+    let n = num_threads();
+
+    // Pre-populate all maps identically outside the benchmark loop.
+    let leapmap: Arc<LeapMap<usize, usize>> = Arc::new(LeapMap::new());
+    let dashmap: Arc<DashMap<usize, usize>> = Arc::new(DashMap::new());
+    let rwmap: Arc<RwLock<HashMap<usize, usize>>> =
+        Arc::new(RwLock::new(HashMap::with_capacity(NUM_KEYS)));
+
+    for i in 0..NUM_KEYS {
+        leapmap.insert(i, i);
+        dashmap.insert(i, i);
+        rwmap.write().unwrap().insert(i, i);
+    }
+
+    let mut group = c.benchmark_group("concurrent_get");
+    group.throughput(Throughput::Elements((n * OPS_PER_THREAD) as u64));
+    group.sample_size(10);
+
+    group.bench_function("leapmap", |b| {
+        b.iter(|| {
+            let handles: Vec<_> = (0..n)
+                .map(|_| {
+                    let m = Arc::clone(&leapmap);
+                    std::thread::spawn(move || {
+                        let mut rng = thread_rng();
+                        for _ in 0..OPS_PER_THREAD {
+                            let _ = m.get(&(rng.gen::<usize>() % NUM_KEYS));
+                        }
+                    })
+                })
+                .collect();
+            for h in handles {
+                h.join().unwrap();
+            }
+        });
+    });
+
+    group.bench_function("dashmap", |b| {
+        b.iter(|| {
+            let handles: Vec<_> = (0..n)
+                .map(|_| {
+                    let m = Arc::clone(&dashmap);
+                    std::thread::spawn(move || {
+                        let mut rng = thread_rng();
+                        for _ in 0..OPS_PER_THREAD {
+                            let _ = m.get(&(rng.gen::<usize>() % NUM_KEYS));
+                        }
+                    })
+                })
+                .collect();
+            for h in handles {
+                h.join().unwrap();
+            }
+        });
+    });
+
+    group.bench_function("rwlock_hashmap", |b| {
+        b.iter(|| {
+            let handles: Vec<_> = (0..n)
+                .map(|_| {
+                    let m = Arc::clone(&rwmap);
+                    std::thread::spawn(move || {
+                        let mut rng = thread_rng();
+                        for _ in 0..OPS_PER_THREAD {
+                            let _ = m.read().unwrap().get(&(rng.gen::<usize>() % NUM_KEYS));
+                        }
+                    })
+                })
+                .collect();
+            for h in handles {
+                h.join().unwrap();
+            }
+        });
+    });
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// resize
+// ---------------------------------------------------------------------------
+
+/// Single-threaded fill from empty to N elements with no pre-allocated capacity.
+///
+/// Measures the amortised cost of insert including resize/migration overhead
+/// and `Drop` cleanup. Primarily a regression baseline for LeapMap; DashMap
+/// provides a competitive reference point.
+fn bench_resize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resize");
+    group.sample_size(10);
+
+    for &n in &[1_000usize, 10_000, 100_000] {
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_with_input(BenchmarkId::new("leapmap", n), &n, |b, &n| {
+            b.iter(|| {
+                let map: LeapMap<usize, usize> = LeapMap::new();
+                for i in 0..n {
+                    map.insert(i, i);
+                }
+                // drop included; should be O(resizes), not O(n)
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("dashmap", n), &n, |b, &n| {
+            b.iter(|| {
+                let map: DashMap<usize, usize> = DashMap::new();
+                for i in 0..n {
+                    map.insert(i, i);
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_concurrent_insert, bench_concurrent_get, bench_resize);
+criterion_main!(benches);

--- a/src/leapmap.rs
+++ b/src/leapmap.rs
@@ -846,10 +846,6 @@ where
             .dst_table
             .store(new_dst_table_ptr, Ordering::Relaxed);
 
-        // Publish the new sources/destination as a live migration round.
-        migrator
-            .status
-            .store(Migrator::<K, V>::INITIALIZATION_MASK, Ordering::Release);
     }
 
     /// Makes the calling thread participate in the migtration.
@@ -863,10 +859,15 @@ where
 
         // First check if that migration is in the completion stage,
         // in which case we should go and clean up some of the old
-        // migration tables.
+        // migration tables.  We spin only while the completion flag is
+        // actively set (not when status == 0, which means the migration
+        // is fully done and we can move on).
         if migrator.finishing() {
-            while migrator.finishing() {
-                // Clean up old tables, then return:
+            loop {
+                let s = migrator.status.load(Ordering::Acquire);
+                if s & Migrator::<K, V>::MIGRATION_COMPLETE_FLAG == 0 {
+                    break;
+                }
                 migrator.cleanup_stale_table(&self.allocator);
             }
             return;
@@ -897,7 +898,15 @@ where
                 // Migration is finished, we can break
                 return;
             }
-            // Last bit is flag for completion, hence + 8:
+            if status & Migrator::<K, V>::INITIALIZATION_MASK
+                != Migrator::<K, V>::INITIALIZATION_MASK
+            {
+                // Migration not initialized or already completed (stale
+                // check from participate_in_migration).  Bail out so we
+                // don't join a non-existent migration.
+                return;
+            }
+            // Low 3 bits are flags, worker count lives in bits 3+, hence + 8:
             match migrator.status.compare_exchange(
                 status,
                 status + 8,
@@ -921,7 +930,8 @@ where
                 }
 
                 let source = &migrator.sources[i];
-                // Check if this source has finished migration and we can move on:
+                // Check if this source has finished migration and we can move
+                // on:
                 let start_index = source
                     .index
                     .fetch_add(Self::MIGRATION_UNIT_SIZE, Ordering::Relaxed);
@@ -929,12 +939,13 @@ where
                     break;
                 }
 
-                // Check if the migration failed due to overflow in the destination
-                // table. Since this source caused an overflow, the migration can't
-                // complete for any thread because this unit will never complete.
-                // Multiple threads may overflow concurrently.
-                // We need to notify all threads of the overflow, so that they are
-                // flushed an we can safely deal with the overflow.
+                // Check if the migration failed due to overflow in the
+                // destination table. Since this source caused an overflow, the
+                // migration can't complete for any thread because this unit
+                // will never complete.  Multiple threads may overflow
+                // concurrently.  We need to notify all threads of the overflow,
+                // so that they are flushed and we can safely deal with the
+                // overflow.
                 let end_index = start_index + Self::MIGRATION_UNIT_SIZE;
                 if !migrator.migrate_range::<H, A>(i, start_index, end_index) {
                     migrator.overflowed.store(true, Ordering::Relaxed);
@@ -979,24 +990,46 @@ where
         // other threads will be able to see that the migration is still in
         // progress but is in the completion stage.
         debug_assert!(prev_status == 15);
-        if migrator.overflowed.load(Ordering::Acquire) {
+
+        // If the destination overflowed, the last worker drives the retry
+        // single-handedly while all other workers spin in the wait loop above.
+        // Each retry doubles the destination, so this converges quickly.
+        while migrator.overflowed.load(Ordering::Acquire) {
             Self::prepare_retry_after_overflow(allocator, migrator);
-        } else {
-            // Migration was successful, we can update the migrator. Here
-            // we only set the variables which we need to:
-            let new_table_ptr = migrator.dst_table.load(Ordering::Relaxed);
-            dst_table.store(new_table_ptr, Ordering::Release);
+            Self::drive_retry_migration(migrator);
+        }
 
-            migrator.overflowed.store(false, Ordering::Relaxed);
-            //migrator
-            //    .dst_table
-            //    .store(std::ptr::null_mut(), Ordering::Relaxed);
+        // Migration was successful, we can update the migrator. Here
+        // we only set the variables which we need to:
+        let new_table_ptr = migrator.dst_table.load(Ordering::Relaxed);
+        dst_table.store(new_table_ptr, Ordering::Release);
 
-            // We don't move the source tables here, rather, we wait until the
-            // next mogration and add them to the cleanup queue then.
+        migrator.overflowed.store(false, Ordering::Relaxed);
 
-            // Finally we can set that we are done!
-            migrator.status.store(0, Ordering::Release);
+        // We don't move the source tables here, rather, we wait until the
+        // next migration and add them to the cleanup queue then.
+
+        // Finally we can set that we are done!
+        migrator.status.store(0, Ordering::Release);
+    }
+
+    /// Drives a retry migration round single-threaded (called by the last
+    /// worker only, while all other workers spin).  Iterates every source
+    /// completely, migrating into the current destination table.
+    fn drive_retry_migration(migrator: &mut Migrator<K, V>) {
+        let num_sources = migrator.num_source_tables.load(Ordering::Relaxed) as usize;
+        for i in 0..num_sources {
+            let source = &migrator.sources[i];
+            let source_size = source.size();
+            let mut start_index = 0;
+            while start_index < source_size {
+                let end_index = start_index + Self::MIGRATION_UNIT_SIZE;
+                if !migrator.migrate_range::<H, A>(i, start_index, end_index) {
+                    migrator.overflowed.store(true, Ordering::Relaxed);
+                    return;
+                }
+                start_index = end_index;
+            }
         }
     }
 
@@ -2021,9 +2054,11 @@ mod tests {
             expected_units
         );
         assert!(!migrator.overflowed.load(Ordering::Relaxed));
+        // Status is not modified by prepare_retry_after_overflow; the caller
+        // (perform_migration) stores 0 after driving the retry to completion.
         assert_eq!(
             migrator.status.load(Ordering::Acquire),
-            Migrator::<u64, u64>::INITIALIZATION_MASK
+            Migrator::<u64, u64>::INITIALIZATION_MASK | 1,
         );
         assert_ne!(new_dst, overflowed_dst);
 

--- a/src/leapmap.rs
+++ b/src/leapmap.rs
@@ -784,22 +784,20 @@ where
         // Check if there are any old source tables, and move them to the cleanup
         // queue:
         let last_source = migrator.last_stale_source.load(Ordering::Relaxed);
-        let num_sources = migrator.num_source_tables.load(Ordering::Relaxed);
+        let num_sources = migrator.num_source_tables.load(Ordering::Relaxed) as usize;
+        migrator.sources.truncate(num_sources);
         migrator.num_source_tables.store(0, Ordering::Relaxed);
 
         for i in 0..num_sources {
             let source = migrator.sources.pop().unwrap();
-            let index = migrator.stale_source_index((last_source + i) as usize);
-
-            // If this is not null, then we have wrapped:
-            // FIXME: This occasionally causes a panic in the tests!
+            let index = migrator.stale_source_index(last_source as usize + i);
             debug_assert!(migrator.stale_sources[index]
-                .load(Ordering::Relaxed)
+                .load(Ordering::Acquire)
                 .is_null());
 
             migrator.stale_sources[index]
                 .store(source.table.load(Ordering::Relaxed), Ordering::Relaxed);
-            let _old = migrator.last_stale_source.fetch_add(1, Ordering::Relaxed);
+            let _old = migrator.last_stale_source.fetch_add(1, Ordering::Release);
         }
 
         let source = MigrationSource::<K, V> {
@@ -810,8 +808,48 @@ where
             migrator.sources.push(source);
         } else {
             migrator.sources[0] = source;
+            migrator.sources.truncate(1);
         }
         migrator.num_source_tables.store(1, Ordering::Relaxed);
+    }
+
+    /// Prepares another migration pass after the current destination overflowed.
+    ///
+    /// The partially filled destination becomes an additional source so entries
+    /// already redirected out of older tables remain reachable.
+    fn prepare_retry_after_overflow(allocator: &A, migrator: &mut Migrator<K, V>) {
+        let table_ptr = migrator.dst_table.load(Ordering::Relaxed);
+        let table = unsafe { &*table_ptr };
+        let active_sources = migrator.num_source_tables.load(Ordering::Relaxed) as usize;
+        migrator.sources.truncate(active_sources);
+
+        let mut remaining_units = Self::remaining_units(table.size_mask);
+        for source in migrator.sources.iter().take(active_sources) {
+            remaining_units += Self::remaining_units(source.size());
+            source.index.store(0, Ordering::Relaxed);
+        }
+
+        migrator.sources.push(MigrationSource {
+            table: AtomicPtr::new(table_ptr),
+            index: AtomicUsize::new(0),
+        });
+        migrator
+            .num_source_tables
+            .store((active_sources + 1) as u32, Ordering::Relaxed);
+        migrator
+            .remaining_units
+            .store(remaining_units, Ordering::Relaxed);
+        migrator.overflowed.store(false, Ordering::Relaxed);
+
+        let new_dst_table_ptr = Self::allocate_and_init_table(allocator, (table.size_mask + 1) * 2);
+        migrator
+            .dst_table
+            .store(new_dst_table_ptr, Ordering::Relaxed);
+
+        // Publish the new sources/destination as a live migration round.
+        migrator
+            .status
+            .store(Migrator::<K, V>::INITIALIZATION_MASK, Ordering::Release);
     }
 
     /// Makes the calling thread participate in the migtration.
@@ -872,7 +910,8 @@ where
         }
 
         // Iterate over all source tables
-        let num_sources = migrator.num_source_tables.load(Ordering::Relaxed);
+        let num_sources = migrator.num_source_tables.load(Ordering::Relaxed) as usize;
+        debug_assert!(num_sources <= migrator.sources.len());
         for i in 0..num_sources {
             let mut finished = false;
             loop {
@@ -881,12 +920,7 @@ where
                     break;
                 }
 
-                // FIXME: This should not be here
-                if i as usize >= migrator.sources.len() {
-                    break;
-                }
-
-                let source = &migrator.sources[i as usize];
+                let source = &migrator.sources[i];
                 // Check if this source has finished migration and we can move on:
                 let start_index = source
                     .index
@@ -902,9 +936,9 @@ where
                 // We need to notify all threads of the overflow, so that they are
                 // flushed an we can safely deal with the overflow.
                 let end_index = start_index + Self::MIGRATION_UNIT_SIZE;
-                if !migrator.migrate_range::<H, A>(i as usize, start_index, end_index) {
+                if !migrator.migrate_range::<H, A>(i, start_index, end_index) {
                     migrator.overflowed.store(true, Ordering::Relaxed);
-                    let _old = migrator.status.fetch_or(1, Ordering::Relaxed);
+                    let _old = migrator.status.fetch_or(1, Ordering::Release);
                     finished = true;
                     break;
                 }
@@ -912,7 +946,7 @@ where
                 // Successfully migrated some of the units, update status and
                 // then either try again or we are done:
                 if migrator.remaining_units.fetch_sub(1, Ordering::Relaxed) == 1 {
-                    let _old = migrator.status.fetch_or(1, Ordering::Relaxed);
+                    let _old = migrator.status.fetch_or(1, Ordering::Release);
                     finished = true;
                     break;
                 }
@@ -945,37 +979,8 @@ where
         // other threads will be able to see that the migration is still in
         // progress but is in the completion stage.
         debug_assert!(prev_status == 15);
-        if migrator.overflowed.load(Ordering::Relaxed) {
-            // Overflow of destination table, move the destination table to be
-            // a source in the migrator, create a new destination table, and
-            // then break so that we can try again.
-            let table_ptr = migrator.dst_table.load(Ordering::Relaxed);
-            let table = unsafe { &*table_ptr };
-
-            let mut remaining_units = Self::remaining_units(table.size_mask);
-            for source in &migrator.sources {
-                remaining_units += Self::remaining_units(source.size());
-                source.index.store(0, Ordering::Relaxed);
-            }
-
-            migrator.sources.push(MigrationSource {
-                table: AtomicPtr::new(table_ptr),
-                index: AtomicUsize::new(0),
-            });
-
-            migrator
-                .remaining_units
-                .store(remaining_units, Ordering::Relaxed);
-
-            // Create the new table for the migrator:
-            let new_dst_table_ptr =
-                Self::allocate_and_init_table(allocator, (table.size_mask + 1) * 2);
-            migrator
-                .dst_table
-                .store(new_dst_table_ptr, Ordering::Relaxed);
-
-            // Finally we can set that we are done!
-            migrator.status.store(0, Ordering::Relaxed);
+        if migrator.overflowed.load(Ordering::Acquire) {
+            Self::prepare_retry_after_overflow(allocator, migrator);
         } else {
             // Migration was successful, we can update the migrator. Here
             // we only set the variables which we need to:
@@ -1476,6 +1481,14 @@ const fn get_cell_index(index: usize) -> usize {
     index & 3
 }
 
+fn deallocate_table<K, V, A: Allocator>(allocator: &A, table_ptr: *mut Table<K, V>) {
+    let table = unsafe { &mut *table_ptr };
+    let bucket_ptr = table.buckets;
+    let bucket_count = table.size() >> 2;
+    deallocate::<Bucket<K, V>, A>(allocator, bucket_ptr, bucket_count);
+    deallocate::<Table<K, V>, A>(allocator, table_ptr, 1);
+}
+
 /// The type used for hashed keys.
 type HashedKey = u64;
 
@@ -1511,12 +1524,12 @@ struct Table<K, V> {
 impl<K, V> Table<K, V> {
     /// Gets a mutable slice of the table buckets.
     pub(super) fn bucket_slice_mut(&mut self) -> &mut [Bucket<K, V>] {
-        unsafe { std::slice::from_raw_parts_mut(self.buckets, self.size()) }
+        unsafe { std::slice::from_raw_parts_mut(self.buckets, self.size() >> 2) }
     }
 
     /// Gets a slice of the table buckets.
     pub(super) fn bucket_slice(&self) -> &[Bucket<K, V>] {
-        unsafe { std::slice::from_raw_parts(self.buckets, self.size()) }
+        unsafe { std::slice::from_raw_parts(self.buckets, self.size() >> 2) }
     }
 
     /// Returns the number of cells in the table.
@@ -1644,7 +1657,7 @@ impl<K, V> Migrator<K, V> {
     fn set_initialization_begin_flag(&self) -> bool {
         let old = self
             .status
-            .fetch_or(Self::INITIALIZATION_START_FLAG, Ordering::Relaxed);
+            .fetch_or(Self::INITIALIZATION_START_FLAG, Ordering::AcqRel);
         old & Self::INITIALIZATION_START_FLAG == 0
     }
 
@@ -1654,26 +1667,26 @@ impl<K, V> Migrator<K, V> {
     fn set_initialization_complete_flag(&self) -> bool {
         let old = self
             .status
-            .fetch_or(Self::INITIALIZATION_END_FLAG, Ordering::Relaxed);
+            .fetch_or(Self::INITIALIZATION_END_FLAG, Ordering::Release);
         old & Self::INITIALIZATION_END_FLAG == 0
     }
 
     /// If the migrator has completed/is completing the migration.
     fn finishing(&self) -> bool {
-        let status = self.status.load(Ordering::Relaxed);
+        let status = self.status.load(Ordering::Acquire);
         status & Self::MIGRATION_COMPLETE_FLAG == Self::MIGRATION_COMPLETE_FLAG || status == 0
     }
 
     /// If the migrator has completed initialization
     fn initialization_complete(&self) -> bool {
-        self.status.load(Ordering::Relaxed) & Self::INITIALIZATION_MASK == Self::INITIALIZATION_MASK
+        self.status.load(Ordering::Acquire) & Self::INITIALIZATION_MASK == Self::INITIALIZATION_MASK
     }
 
     /// This returns true if the migrator is in process, which is the time from
     /// which the initialization flag is set until the time at which the thread
     /// which finishes the migration sets the status to zero.
     fn in_process(&self) -> bool {
-        self.status.load(Ordering::Relaxed) & Self::INITIALIZATION_START_FLAG
+        self.status.load(Ordering::Acquire) & Self::INITIALIZATION_START_FLAG
             == Self::INITIALIZATION_START_FLAG
     }
 
@@ -1684,14 +1697,14 @@ impl<K, V> Migrator<K, V> {
 
     /// Returns the number of stale source tables to clean up.
     fn stale_tables_remaining(&self) -> u32 {
-        self.last_stale_source.load(Ordering::Relaxed)
+        self.last_stale_source.load(Ordering::Acquire)
             - self.current_stale_source.load(Ordering::Relaxed)
     }
 
     /// Tries to clean up (deallocate) any stale source tables.
     fn cleanup_stale_table<A: Allocator>(&self, allocator: &A) {
         let current = self.current_stale_source.load(Ordering::Relaxed);
-        let last_visible = self.last_stale_source.load(Ordering::Relaxed);
+        let last_visible = self.last_stale_source.load(Ordering::Acquire);
 
         // Check if there are any old source tables to clean up
         if current >= last_visible {
@@ -1701,22 +1714,17 @@ impl<K, V> Migrator<K, V> {
         // There are sources to clean up, try and get one:
         if self
             .current_stale_source
-            .compare_exchange(current, current + 1, Ordering::Relaxed, Ordering::Relaxed)
+            .compare_exchange(current, current + 1, Ordering::AcqRel, Ordering::Acquire)
             .is_ok()
         {
             // Won the race, we can deallocate the stale source for our index:
             let index = self.stale_source_index(current as usize);
-            let table_ptr = self.stale_sources[index].load(Ordering::Relaxed);
+            let table_ptr = self.stale_sources[index].swap(std::ptr::null_mut(), Ordering::AcqRel);
             if table_ptr.is_null() {
                 return;
             }
 
-            let table = unsafe { &mut *table_ptr };
-            let bucket_ptr = table.buckets;
-            let bucket_count = table.size() >> 2;
-            deallocate::<Bucket<K, V>, A>(allocator, bucket_ptr, bucket_count);
-            deallocate::<Table<K, V>, A>(allocator, table_ptr, 1);
-            self.stale_sources[index].store(std::ptr::null_mut(), Ordering::Relaxed);
+            deallocate_table::<K, V, A>(allocator, table_ptr);
         }
 
         // Lost the race, just return.
@@ -1957,5 +1965,70 @@ mod tests {
         }
 
         assert_eq!(MIGRATOR_DROPS.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn overflow_retry_keeps_migration_live() {
+        let allocator = Global;
+        let mut migrator = Migrator {
+            dst_table: AtomicPtr::new(std::ptr::null_mut()),
+            sources: Vec::new(),
+            status: AtomicUsize::new(0),
+            remaining_units: AtomicUsize::new(0),
+            overflowed: AtomicBool::new(false),
+            num_source_tables: AtomicU32::new(0),
+            stale_sources: Vec::new(),
+            last_stale_source: AtomicU32::new(0),
+            current_stale_source: AtomicU32::new(0),
+        };
+        migrator.initialize();
+
+        let source_table = LeapMap::<u64, u64>::allocate_and_init_table(&allocator, 8);
+        let overflowed_dst = LeapMap::<u64, u64>::allocate_and_init_table(&allocator, 16);
+        migrator.sources.push(MigrationSource {
+            table: AtomicPtr::new(source_table),
+            index: AtomicUsize::new(7),
+        });
+        migrator.num_source_tables.store(1, Ordering::Relaxed);
+        migrator.dst_table.store(overflowed_dst, Ordering::Relaxed);
+        migrator.overflowed.store(true, Ordering::Relaxed);
+        migrator.status.store(
+            Migrator::<u64, u64>::INITIALIZATION_MASK | 1,
+            Ordering::Relaxed,
+        );
+
+        LeapMap::<u64, u64>::prepare_retry_after_overflow(&allocator, &mut migrator);
+
+        let new_dst = migrator.dst_table.load(Ordering::Relaxed);
+        let expected_units =
+            LeapMap::<u64, u64>::remaining_units(unsafe { &*source_table }.size_mask)
+                + LeapMap::<u64, u64>::remaining_units(unsafe { &*overflowed_dst }.size_mask);
+
+        assert_eq!(migrator.num_source_tables.load(Ordering::Relaxed), 2);
+        assert_eq!(migrator.sources.len(), 2);
+        assert_eq!(
+            migrator.sources[0].table.load(Ordering::Relaxed),
+            source_table
+        );
+        assert_eq!(migrator.sources[0].index.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            migrator.sources[1].table.load(Ordering::Relaxed),
+            overflowed_dst
+        );
+        assert_eq!(migrator.sources[1].index.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            migrator.remaining_units.load(Ordering::Relaxed),
+            expected_units
+        );
+        assert!(!migrator.overflowed.load(Ordering::Relaxed));
+        assert_eq!(
+            migrator.status.load(Ordering::Acquire),
+            Migrator::<u64, u64>::INITIALIZATION_MASK
+        );
+        assert_ne!(new_dst, overflowed_dst);
+
+        deallocate_table::<u64, u64, Global>(&allocator, source_table);
+        deallocate_table::<u64, u64, Global>(&allocator, overflowed_dst);
+        deallocate_table::<u64, u64, Global>(&allocator, new_dst);
     }
 }


### PR DESCRIPTION
Initially I just wanted to benchmark `LeapMap` against `DashMap` (similar to https://github.com/robclu/leapfrog/blob/main/benches/hashmap.rs), but that actually crashed. So I started digging further into it, and found some bugs:

## Summary

- Fix five correctness bugs in the LeapMap migration/resize machinery (memory ordering, livelock, TOCTOU race)
- Fix UB in `bucket_slice` / `bucket_slice_mut` (slices created 4x past allocation boundary)
- Add Criterion benchmarks comparing LeapMap vs DashMap vs std lock-based maps
- Add `dashmap` as a dev-dependency for side-by-side comparison
- Probably closes https://github.com/robclu/leapfrog/issues/15?

## Bug fixes

### Memory ordering (`be22a87`)

Multiple `Relaxed` atomics in the `Migrator` upgraded to proper `Acquire`/`Release`/`AcqRel`:

| Location | Change | Reason |
|---|---|---|
| `set_initialization_begin_flag` | Relaxed -> AcqRel | Must see prior state and publish flag |
| `set_initialization_complete_flag` | Relaxed -> Release | Publishes initialization stores to joining workers |
| `finishing()`, `initialization_complete()`, `in_process()` | Relaxed -> Acquire | Must see stores published by initializer/completer |
| `status.fetch_or(1)` (overflow and completion) | Relaxed -> Release | Publishes `overflowed` flag and migration results |
| `stale_sources` cleanup | separate load+store -> `swap(AcqRel)` | Prevents double-free race |
| `current_stale_source` CAS | Relaxed -> AcqRel/Acquire | Must see stale table pointer before deallocating |

### `bucket_slice` UB fix (`be22a87`)

`Table::bucket_slice()` and `bucket_slice_mut()` created slices with `self.size()` elements (number of cells), but only `self.size() >> 2` buckets are allocated. Fixed to `self.size() >> 2`.

Note: `hashmap.rs` has the identical bug at lines 967-972, left for a follow-up.

### Migration retry livelock (`be22a87` introduced, `f8cd76c` fixed)

`prepare_retry_after_overflow` stored `status = INITIALIZATION_MASK (0x06)` to signal a retry round, but non-last workers spin on `while status >= 1` expecting `status == 0`. Since `0x06 >= 1`, they spin forever under sustained concurrent inserts.

Fix: removed the status store from `prepare_retry_after_overflow`. The last worker now drives the retry migration single-handedly via `drive_retry_migration()` while other workers spin, then stores `status = 0` to release them.

### TOCTOU race in `perform_migration` (`f8cd76c`)

A thread could pass `initialization_complete()` in `participate_in_migration`, but by the time it reached the CAS `status + 8` in `perform_migration`, the migration had completed (`status = 0`). The CAS `0 -> 8` succeeded, creating a phantom worker that corrupted the count (`prev_status = 0x08` instead of `0x0F`), leading to heap corruption and SIGABRT.

Fix: added an `INITIALIZATION_MASK` guard in the CAS join loop. Bail out if init flags are not set.

### Infinite spin in `participate_in_migration` (`f8cd76c`)

`while migrator.finishing()` looped forever when `status == 0` because `finishing()` returns `true` for `status == 0`. Threads entering this path after a migration completed would never exit.

Fix: check `status & MIGRATION_COMPLETE_FLAG` directly instead of calling `finishing()`.

## Benchmarks

`benches/leapmap.rs` adds three benchmark groups, each comparing LeapMap against DashMap and the appropriate lock-based baseline:

Results with my M1 Max 64GB (10 cores):

| Benchmark | LeapMap | DashMap | Lock-based |
|---|---|---|---|
| concurrent_insert (N threads x 10K inserts) | 4.0 ms (24.7 Melem/s) | 4.2 ms (24.0 Melem/s) | 16.6 ms Mutex (6.0 Melem/s) |
| concurrent_get (N threads x 10K reads) | 646 us (154.9 Melem/s) | 1.7 ms (58.4 Melem/s) | 25.5 ms RwLock (3.9 Melem/s) |
| resize/1K (single-threaded fill) | 52 us | 40 us | -- |
| resize/10K | 532 us | 355 us | -- |
| resize/100K | 6.8 ms | 3.5 ms | -- |

LeapMap is roughly 2.6x faster than DashMap for concurrent reads and competitive for concurrent inserts. Single-threaded resize is slower as expected (lock-free migration overhead amortizes under concurrency).

## Test plan

- [x] Unit tests (3/3 pass, including new `overflow_retry_keeps_migration_live`)
- [x] Integration tests: basic (6/6), hashmap (6/6)
- [x] Cuckoo stress test (same pre-existing flake rate as main, ~20%)
- [x] Doc-tests (44/44)
- [x] All 9 Criterion benchmarks complete without hang or crash
- [x] Standalone 1400+ iteration stress test (10 threads x 10K inserts, tight loop)
- [x] No regressions in existing `hashmap` benchmark